### PR TITLE
Rename Platforms

### DIFF
--- a/components/unstable_balloon_ground.js
+++ b/components/unstable_balloon_ground.js
@@ -1,8 +1,7 @@
-var COLOR = 'red';
 var DEFAULT_RAISE_HEIGHT = -500; // -y is 'north'/'up'
 var DEFAULT_RAISE_SPEED = -100;
 
-Crafty.c("UnstableRaisingGround", {
+Crafty.c("UnstableBalloonGround", {
     init: function () {
         this.addComponent("2D, DOM, Gravity, Motion, pf_sad_up");
         this.attr({x: 0, y: 0, w: 101, h: 160, ay: 0})

--- a/components/unstable_raising_ground.js
+++ b/components/unstable_raising_ground.js
@@ -4,7 +4,7 @@ const VERTICAL_MULTIPLIERS = {
     HIGH: 2.0,
 };
 
-Crafty.c("UnstableRaisingGround2", {
+Crafty.c("UnstableRaisingGround", {
     init: function () {
         this.addComponent("2D, DOM, Delay, Motion, pf_sad_up");
         this.attr({x: 0, y: 0, w: 101, h: 160});

--- a/components/unstable_raising_ground.js
+++ b/components/unstable_raising_ground.js
@@ -61,7 +61,6 @@ Crafty.c("UnstableRaisingGround", {
     place: function (x, y) {
         this.x = x;
         this.y = y;
-        this.originalX = x;
         this.originalY = y;
 
         return this;

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
     <script type="text/javascript" src="components/unstable_balloon_ground.js"></script>
     <script type="text/javascript" src="components/unstable_decay_ground.js"></script>
     <script type="text/javascript" src="components/unstable_dropping_ground.js"></script>
-    <script type="text/javascript" src="components/unstable_raising_ground2.js"></script>
+    <script type="text/javascript" src="components/unstable_raising_ground.js"></script>
     <script type="text/javascript" src="components/unstable_rotating_ground.js"></script>
     <script type="text/javascript" src="components/unstable_strafing_ground.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -51,9 +51,9 @@
     <script type="text/javascript" src="components/spike_bush.js"></script>
     <script type="text/javascript" src="components/player_notifications.js"></script>
 
+    <script type="text/javascript" src="components/unstable_balloon_ground.js"></script>
     <script type="text/javascript" src="components/unstable_decay_ground.js"></script>
     <script type="text/javascript" src="components/unstable_dropping_ground.js"></script>
-    <script type="text/javascript" src="components/unstable_raising_ground.js"></script>
     <script type="text/javascript" src="components/unstable_raising_ground2.js"></script>
     <script type="text/javascript" src="components/unstable_rotating_ground.js"></script>
     <script type="text/javascript" src="components/unstable_strafing_ground.js"></script>

--- a/scenes/level0.js
+++ b/scenes/level0.js
@@ -34,7 +34,7 @@ Crafty.defineScene('Level0', function () {
     const ground6 = Crafty.e('Ground')
         .place(700, 580)
 
-    const upPlatform = Crafty.e('UnstableRaisingGround2')
+    const upPlatform = Crafty.e('UnstableRaisingGround')
         .place(400, 450)
         .movementDirection(VERTICAL_DIRECTION.UP)
         .maxMovementDistance(200)

--- a/scenes/level1.js
+++ b/scenes/level1.js
@@ -12,7 +12,10 @@ Crafty.defineScene("Level1", function () {
     //     .attr({x: 0, y: 0})
     //Raising Platform
     // var raisingGround = Crafty.e('UnstableRaisingGround')
-    //     .attr({x: 0, y: 0})
+    //     .place(0, 0)
+    //     .movementDirection(VERTICAL_DIRECTION.UP)
+    //     .maxMovementDistance(200)
+    //     .movementSpeed(100);
     //Decaying Platform
     // var decayGround = Crafty.e('UnstableDecayGround')
     //     .attr({x: 0, y: 0})
@@ -98,7 +101,7 @@ Crafty.defineScene("Level1", function () {
     var platform11 = Crafty.e('Ground')
         .attr({x: 2700, y: -350})
     var raisePlatform1 = Crafty.e('UnstableRaisingGround')
-        .attr({x: 2900, y: -350})
+        .place(2900, -350)
     var platform13 = Crafty.e('Ground')
         .attr({x: 3000, y: -650})
 
@@ -128,7 +131,7 @@ Crafty.defineScene("Level1", function () {
     var platform20 = Crafty.e('Ground')
         .attr({x: 4400, y: -700})
     var raisePlatform2 = Crafty.e('UnstableRaisingGround')
-        .attr({x: 4550, y: -700})
+        .place(4550, -700)
     var sanityBooster = Crafty.e('SanityBooster')
         .attr({x: 4580, y: -710})
     //enemy
@@ -202,7 +205,7 @@ Crafty.defineScene("Level1", function () {
 
     //Raising Platform
     var raisePlatform2 = Crafty.e('UnstableRaisingGround')
-        .attr({x: 5550, y: -1000})
+        .place(5550, -1000)
 
     //Moving Platform + Sanity check + Dropping ground
     var movingPlatform = Crafty.e('UnstableStrafingGround')
@@ -241,13 +244,13 @@ Crafty.defineScene("Level1", function () {
 
     //Raising Jumpers
     var raising4 = Crafty.e('UnstableRaisingGround')
-        .attr({x: 7800, y: -650})
+        .place(7800, -650)
     var raising5 = Crafty.e('UnstableRaisingGround')
-        .attr({x: 8000, y: -950})
+        .place(8000, -950)
     var raising6 = Crafty.e('UnstableRaisingGround')
-        .attr({x: 8200, y: -1250})
+        .place(8200, -1250)
     var raising6 = Crafty.e('UnstableRaisingGround')
-        .attr({x: 8200, y: -1250})
+        .place(8200, -1250)
     var platform36 = Crafty.e('Ground')
         .attr({x: 8500, y: -1300})
 
@@ -284,27 +287,27 @@ Crafty.defineScene("Level1", function () {
     var dropPlatform11 = Crafty.e('UnstableDroppingGround')
         .attr({x: 10250, y: -1150})
     var raising6 = Crafty.e('UnstableRaisingGround')
-        .attr({x: 10400, y: -1150})
+        .place(10400, -1150)
     var dropPlatform11 = Crafty.e('UnstableDroppingGround')
         .attr({x: 10475, y: -1150})
     var raising6 = Crafty.e('UnstableRaisingGround')
-        .attr({x: 10625, y: -1150})
+        .place(10625, -1150)
     var dropPlatform11 = Crafty.e('UnstableDroppingGround')
         .attr({x: 10700, y: -1150})
     var raising6 = Crafty.e('UnstableRaisingGround')
-        .attr({x: 10850, y: -1150})
+        .place(10850, -1150)
     var dropPlatform11 = Crafty.e('UnstableDroppingGround')
         .attr({x: 10925, y: -1150})
     var raising6 = Crafty.e('UnstableRaisingGround')
-        .attr({x: 11075, y: -1150})
+        .place(11075, -1150)
     var dropPlatform11 = Crafty.e('UnstableDroppingGround')
         .attr({x: 11150, y: -1150})
     var raising6 = Crafty.e('UnstableRaisingGround')
-        .attr({x: 11300, y: -1150})
+        .place(11300, -1150)
     var dropPlatform11 = Crafty.e('UnstableDroppingGround')
         .attr({x: 11375, y: -1150})
     var raising6 = Crafty.e('UnstableRaisingGround')
-        .attr({x: 11525, y: -1150})
+        .place(11525, -1150)
     var sanityzone1 = Crafty.e('SanityZone')
         .attr({x: 10250, y: -1250, w: 1500, h: 100})
     //roof spikes
@@ -347,7 +350,7 @@ Crafty.defineScene("Level1", function () {
     var platform41 = Crafty.e('Ground')
         .attr({x: 11850, y: -1000})
     var raising = Crafty.e('UnstableRaisingGround')
-        .attr({x: 12000, y: -1000})
+        .place(12000, -1000)
 
     //Goal platform
     var platform41 = Crafty.e('Ground')

--- a/scenes/level2.js
+++ b/scenes/level2.js
@@ -11,7 +11,10 @@ Crafty.defineScene("Level2", function () {
     //     .attr({x: 0, y: 0})
     //Raising Platform
     // var raisingGround = Crafty.e('UnstableRaisingGround')
-    //     .attr({x: 0, y: 0})
+    //     .place(0, 0)
+    //     .movementDirection(VERTICAL_DIRECTION.UP)
+    //     .maxMovementDistance(200)
+    //     .movementSpeed(100);
     //Decaying Platform
     // var decayGround = Crafty.e('UnstableDecayGround')
     //     .attr({x: 0, y: 0})
@@ -96,7 +99,7 @@ Crafty.defineScene("Level2", function () {
         .attr({x: 2450, y: -50})
     //Raising Platform
     var raisingGround = Crafty.e('UnstableRaisingGround')
-        .attr({x: 2600, y: -50})
+        .place(2600, -50)
     var platform = Crafty.e('Ground')
         .attr({x: 2675, y: -300})
     //Walking Enemy Platform
@@ -128,7 +131,7 @@ Crafty.defineScene("Level2", function () {
     var spike = Crafty.e('SpikeBush')
         .attr({x: 4160, y: -520})
     var raisingGround = Crafty.e('UnstableRaisingGround')
-        .attr({x: 4320, y: -500})
+        .place(4320, -500)
     //Movement Platform for Consumable
     var movingPlatform = Crafty.e('UnstableStrafingGround')
         .place(4450, -800)
@@ -182,7 +185,7 @@ Crafty.defineScene("Level2", function () {
         .attr({x: 3950, y: -950})
         .color("orange")
     var raisingGround = Crafty.e('UnstableRaisingGround')
-        .attr({x: 4100, y: -950})
+        .place(4100, -950)
     //Enemy Platforms
     var platform = Crafty.e('Ground')
         .attr({x: 4200, y: -1300})

--- a/scenes/level3.js
+++ b/scenes/level3.js
@@ -11,7 +11,10 @@ Crafty.defineScene("Level3", function () {
     //     .attr({x: 0, y: 0})
     //Raising Platform
     // var raisingGround = Crafty.e('UnstableRaisingGround')
-    //     .attr({x: 0, y: 0})
+    //     .place(0, 0)
+    //     .movementDirection(VERTICAL_DIRECTION.UP)
+    //     .maxMovementDistance(200)
+    //     .movementSpeed(100);
     //Decaying Platform
     // var decayGround = Crafty.e('UnstableDecayGround')
     //     .attr({x: 0, y: 0})

--- a/scenes/level4.js
+++ b/scenes/level4.js
@@ -11,7 +11,10 @@ Crafty.defineScene("Level4", function () {
     //     .attr({x: 0, y: 0})
     //Raising Platform
     // var raisingGround = Crafty.e('UnstableRaisingGround')
-    //     .attr({x: 0, y: 0})
+    //     .place(0, 0)
+    //     .movementDirection(VERTICAL_DIRECTION.UP)
+    //     .maxMovementDistance(200)
+    //     .movementSpeed(100);
     //Decaying Platform
     // var decayGround = Crafty.e('UnstableDecayGround')
     //     .attr({x: 0, y: 0})

--- a/scenes/level5.js
+++ b/scenes/level5.js
@@ -11,7 +11,10 @@ Crafty.defineScene("Level5", function () {
     //     .attr({x: 0, y: 0})
     //Raising Platform
     // var raisingGround = Crafty.e('UnstableRaisingGround')
-    //     .attr({x: 0, y: 0})
+    //     .place(0, 0)
+    //     .movementDirection(VERTICAL_DIRECTION.UP)
+    //     .maxMovementDistance(200)
+    //     .movementSpeed(100);
     //Decaying Platform
     // var decayGround = Crafty.e('UnstableDecayGround')
     //     .attr({x: 0, y: 0})

--- a/scenes/level_horse.js
+++ b/scenes/level_horse.js
@@ -12,7 +12,10 @@ Crafty.defineScene("LevelHorse", function () {
     //     .attr({x: 0, y: 0})
     //Raising Platform
     // var raisingGround = Crafty.e('UnstableRaisingGround')
-    //     .attr({x: 0, y: 0})
+    //     .place(0, 0)
+    //     .movementDirection(VERTICAL_DIRECTION.UP)
+    //     .maxMovementDistance(200)
+    //     .movementSpeed(100);
     //Decaying Platform
     // var decayGround = Crafty.e('UnstableDecayGround')
     //     .attr({x: 0, y: 0})


### PR DESCRIPTION
The original raising platform has been called the Balloon platform (blame Josh).
The newer one has been renamed to raising platform.